### PR TITLE
combining into tally, plot_info, html plot targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .Ruserdata
 1_fetch/tmp/*
 !1_fetch/tmp/state_splits.yml
+*.png
+*.html

--- a/123_state_tasks.yml
+++ b/123_state_tasks.yml
@@ -15,8 +15,9 @@ packages:
 
 sources:
   - 1_fetch/src/get_site_data.R
-  - 2_process/src/tally_site_obs.R
   - 3_visualize/src/plot_site_data.R
+  - 2_process/src/tally_site_obs.R
+  - 123_state_tasks.R
 
 file_extensions:
   - "ind"
@@ -24,24 +25,8 @@ file_extensions:
 targets:
   123_state_tasks:
     depends:
-      - WI_data
-      - WI_tally
-      - '3_visualize/out/timeseries_WI.png'
-      - MN_data
-      - MN_tally
-      - '3_visualize/out/timeseries_MN.png'
-      - MI_data
-      - MI_tally
-      - '3_visualize/out/timeseries_MI.png'
-      - IL_data
-      - IL_tally
-      - '3_visualize/out/timeseries_IL.png'
-      - IN_data
-      - IN_tally
-      - '3_visualize/out/timeseries_IN.png'
-      - IA_data
-      - IA_tally
-      - '3_visualize/out/timeseries_IA.png'
+      - obs_tallies_promise
+      - timeseries_plots.yml_promise
 
   # --- WI --- #
   
@@ -98,14 +83,61 @@ targets:
   3_visualize/out/timeseries_IN.png:
     command: plot_site_data(out_file = target_name, site_data = IN_data, parameter)
 
-  # --- IA --- #
+  # --- VA --- #
   
-  IA_data:
-    command: get_site_data('1_fetch/tmp/inventory_IA.tsv', parameter)
+  VA_data:
+    command: get_site_data('1_fetch/tmp/inventory_VA.tsv', parameter)
 
-  IA_tally:
-    command: tally_site_obs(site_data = IA_data)
+  VA_tally:
+    command: tally_site_obs(site_data = VA_data)
 
-  3_visualize/out/timeseries_IA.png:
-    command: plot_site_data(out_file = target_name, site_data = IA_data, parameter)
+  3_visualize/out/timeseries_VA.png:
+    command: plot_site_data(out_file = target_name, site_data = VA_data, parameter)
 
+  # --- UT --- #
+  
+  UT_data:
+    command: get_site_data('1_fetch/tmp/inventory_UT.tsv', parameter)
+
+  UT_tally:
+    command: tally_site_obs(site_data = UT_data)
+
+  3_visualize/out/timeseries_UT.png:
+    command: plot_site_data(out_file = target_name, site_data = UT_data, parameter)
+
+  # --- Overall job --- #
+
+  obs_tallies_promise:
+    command: combine_obs_tallies(
+      `WI_tally`,
+      '3_visualize/out/timeseries_WI.png',
+      `MN_tally`,
+      '3_visualize/out/timeseries_MN.png',
+      `MI_tally`,
+      '3_visualize/out/timeseries_MI.png',
+      `IL_tally`,
+      '3_visualize/out/timeseries_IL.png',
+      `IN_tally`,
+      '3_visualize/out/timeseries_IN.png',
+      `VA_tally`,
+      '3_visualize/out/timeseries_VA.png',
+      `UT_tally`,
+      '3_visualize/out/timeseries_UT.png')
+    
+  timeseries_plots.yml_promise:
+    command: summarize_timeseries_plots(I('3_visualize/out/timeseries_plots.yml'),
+      `WI_tally`,
+      '3_visualize/out/timeseries_WI.png',
+      `MN_tally`,
+      '3_visualize/out/timeseries_MN.png',
+      `MI_tally`,
+      '3_visualize/out/timeseries_MI.png',
+      `IL_tally`,
+      '3_visualize/out/timeseries_IL.png',
+      `IN_tally`,
+      '3_visualize/out/timeseries_IN.png',
+      `VA_tally`,
+      '3_visualize/out/timeseries_VA.png',
+      `UT_tally`,
+      '3_visualize/out/timeseries_UT.png')
+    

--- a/1_fetch/tmp/state_splits.yml
+++ b/1_fetch/tmp/state_splits.yml
@@ -1,7 +1,8 @@
-1_fetch/tmp/inventory_IA.tsv: dfc6edf4a80f4f9933eea5a943372110
-1_fetch/tmp/inventory_IL.tsv: 90daa9221857630eec511de7b8691cee
-1_fetch/tmp/inventory_IN.tsv: 5692faf644d71386f381994643cd25e0
-1_fetch/tmp/inventory_MI.tsv: 11af29d9de1eb3105d66b50dd82d1839
-1_fetch/tmp/inventory_MN.tsv: 66e3f77a3570728e3f13406d5c764f67
-1_fetch/tmp/inventory_WI.tsv: cd64a5cff8dacbe68ed8cba70a081b60
+1_fetch/tmp/inventory_IL.tsv: e1b77bf74d05609a3afe1500b85c56c4
+1_fetch/tmp/inventory_IN.tsv: ffce20e930dbe1cd8febcf308669fe6c
+1_fetch/tmp/inventory_MI.tsv: bb2c82b8f109ae1934958ce82dda417c
+1_fetch/tmp/inventory_MN.tsv: 20875093f78f3ce4270773b9719f3244
+1_fetch/tmp/inventory_UT.tsv: fb5dcff59d2e0327fe57d987fe887527
+1_fetch/tmp/inventory_VA.tsv: d96981c6b5186d34ba4333c2c296f211
+1_fetch/tmp/inventory_WI.tsv: f9394f91c45e94788167e26ca5c65d94
 

--- a/remake.yml
+++ b/remake.yml
@@ -7,22 +7,28 @@ packages:
   - urbnmapr
   - rnaturalearth
   - cowplot
+  - leaflet
+  - leafpop
+  - htmlwidgets
 
 sources:
   - 1_fetch/src/find_oldest_sites.R
   - 1_fetch/src/get_site_data.R
   - 3_visualize/src/map_sites.R
+  - 3_visualize/src/plot_data_coverage.R
+  - 3_visualize/src/map_timeseries.R
   - 123_state_tasks.R
 
 targets:
   main:
     depends:
       - 3_visualize/out/site_map.png
-      - state_tasks
+      - 3_visualize/out/data_coverage.png
+      - 3_visualize/out/timeseries_map.html
 
   # Configuration
   states:
-    command: c(I(c('WI','MN','MI','IL','IN','IA')))
+    command: c(I(c('WI','MN','MI','IL','IN','VA','UT')))
   parameter:
     command: c(I('00060'))
 
@@ -31,12 +37,27 @@ targets:
   oldest_active_sites:
     command: find_oldest_sites(states, parameter)
 
-  state_tasks:
+  states_combiners:
     command: do_state_tasks(oldest_active_sites, '1_fetch/src/get_site_data.R',
-                            '3_visualize/src/plot_site_data.R', '2_process/src/tally_site_obs.R')
+                            '3_visualize/src/plot_site_data.R',
+                            '2_process/src/tally_site_obs.R',
+                            '123_state_tasks.R')
     depends:
         - parameter
+
+  obs_tallies:
+    command: pluck(states_combiners, target_name)
+
+  timeseries_plots_info:
+    command: pluck(states_combiners, target_name)
 
   # Map oldest sites
   3_visualize/out/site_map.png:
     command: map_sites(oldest_active_sites, target_name)
+
+  # map site tallies
+  3_visualize/out/data_coverage.png:
+    command: plot_data_coverage(out_file = target_name, oldest_site_tallies = obs_tallies)
+  
+  3_visualize/out/timeseries_map.html:
+    command: map_timeseries(out_file = target_name, site_info = oldest_active_sites, plot_info = timeseries_plots_info)


### PR DESCRIPTION
thoughts: 

* That was mental a workout! It was a very good exercise - well thought out - challenging but I didn't feel like I was spending time debugging things that didn't pertain to the concepts.
* I have to say that the combiners piece felt like it could be simpler. Why can't we just make another special `task_step` that can take all the targets from a previous `task_step`? ... a sort of special `combiner_task_step`? I feel like that would be more intuitive than using the `finalize_funs` and `final_targets` and then you wouldn't have to manually split out the arguments. I don't know the source code well enough to know if this route would even be feasible, but just wanted to throw it out there. Maybe it's also not really a problem and once you just get used to it it is fine.
